### PR TITLE
[Critstun patch part 3]

### DIFF
--- a/bin/Areas/Area.js
+++ b/bin/Areas/Area.js
@@ -91,12 +91,19 @@ class Area {
 
         // Load max rarity/quality item
         res = await conn.query(
-            "SELECT DISTINCT itemsrarities.nomRarity " +
-            "FROM itemsbase " +
-            "INNER JOIN itemsrarities ON itemsrarities.idRarity = itemsbase.idRarity " +
-            "INNER JOIN areasitems ON areasitems.idBaseItem = itemsbase.idBaseItem AND areasitems.idArea = " + this.id + " " +
-            "GROUP BY itemsrarities.idRarity DESC LIMIT 1;"
-        );
+            `SELECT
+                DISTINCT itemsrarities.idRarity, itemsrarities.nomRarity
+                FROM
+                itemsbase
+                INNER JOIN itemsrarities ON itemsrarities.idRarity = itemsbase.idRarity
+                INNER JOIN areasitems ON areasitems.idBaseItem = itemsbase.idBaseItem
+                AND areasitems.idArea = ?
+                GROUP BY
+                itemsrarities.idRarity
+                ORDER BY itemsrarities.idRarity DESC
+                LIMIT 1`
+            , [this.id]);
+
         if (res[0]) {
             this.maxItemRarity = res[0]["nomRarity"];
         }
@@ -187,10 +194,6 @@ class Area {
             }
         }
         return this.monsters[index].getMonsters();
-    }
-
-    getMaxItemQuality() {
-        return this.maxItemRarity;
     }
 
     /**
@@ -457,13 +460,13 @@ class Area {
 
     async getMaxItemQuality() {
         let res = await conn.query(
-            "SELECT DISTINCT itemsrarities.nomRarity FROM itemsbase INNER JOIN itemsrarities ON itemsrarities.idRarity = itemsbase.idRarity INNER JOIN areasitems ON areasitems.idBaseItem = itemsbase.idBaseItem AND areasitems.idArea = ? GROUP BY itemsrarities.idRarity DESC LIMIT 1;", [this.id]);
+            "SELECT DISTINCT itemsrarities.idRarity, itemsrarities.nomRarity FROM itemsbase INNER JOIN itemsrarities ON itemsrarities.idRarity = itemsbase.idRarity INNER JOIN areasitems ON areasitems.idBaseItem = itemsbase.idBaseItem AND areasitems.idArea = ? GROUP BY itemsrarities.idRarity ORDER BY itemsrarities.idRarity DESC LIMIT 1;", [this.id]);
         return res[0] != null ? res[0]["nomRarity"] : "common";
     }
 
     async getMinItemQuality() {
         let res = await conn.query(
-            "SELECT DISTINCT itemsrarities.nomRarity FROM itemsbase INNER JOIN itemsrarities ON itemsrarities.idRarity = itemsbase.idRarity INNER JOIN areasitems ON areasitems.idBaseItem = itemsbase.idBaseItem AND areasitems.idArea = ? GROUP BY itemsrarities.idRarity ASC LIMIT 1;", [this.id]);
+            "SELECT DISTINCT itemsrarities.idRarity, itemsrarities.nomRarity FROM itemsbase INNER JOIN itemsrarities ON itemsrarities.idRarity = itemsbase.idRarity INNER JOIN areasitems ON areasitems.idBaseItem = itemsbase.idBaseItem AND areasitems.idArea = ? GROUP BY itemsrarities.idRarity ORDER BY itemsrarities.idRarity ASC LIMIT 1;", [this.id]);
         return res[0] != null ? res[0]["nomRarity"] : "common";
     }
 
@@ -516,7 +519,7 @@ class Area {
     }
 
     minMaxLevelToString() {
-        return this.minLevel != this.maxLevel ? this.minLevel + "-" + this.maxLevel : this.maxLevel + "";
+        return this.minLevel !== this.maxLevel ? this.minLevel + "-" + this.maxLevel : this.maxLevel + "";
     }
 
     /**

--- a/bin/Entities/WorldEntity.js
+++ b/bin/Entities/WorldEntity.js
@@ -16,6 +16,7 @@ class WorldEntity {
     updateStats() {
         this.maxHP = 10 + this.getStat("constitution") * 10;
         this.actualHP = this.maxHP;
+        this.consecutiveStuns = 0;
     }
 
     damageCalcul() {

--- a/bin/Entities/WorldEntity.js
+++ b/bin/Entities/WorldEntity.js
@@ -10,6 +10,7 @@ class WorldEntity {
         this.maxHP = 0;
         this.level = 0;
         this.stats = new Stats();
+        this.consecutiveStuns = 0;
     }
 
     updateStats() {

--- a/bin/Entities/WorldEntity.js
+++ b/bin/Entities/WorldEntity.js
@@ -18,8 +18,8 @@ class WorldEntity {
     }
 
     damageCalcul() {
-        let baseDamage = (this.getStat("strength") + 1) * 2;
-        return Math.ceil(Math.random() * (baseDamage * 1.25 - baseDamage * 0.75) + baseDamage * 0.75);
+        let baseDamage = this.getStat("strength") + 1;
+        return Math.ceil(Math.random() * 2.5 * baseDamage);
     }
 
     getLevel() {

--- a/bin/Fight/Fight.js
+++ b/bin/Fight/Fight.js
@@ -122,7 +122,6 @@ class Fight {
         let done = 0;
         let critical = false;
         let stun = false;
-        const maxConsecutiveStuns = 1;
 
         let attacker = this.entities[this.initiative[0]][this.initiative[1]];
         let defender = this.getDefender(this.entities[this.initiative[0] == 0 ? 1 : 0]);
@@ -136,7 +135,7 @@ class Fight {
 
         // Critical hit and stun
         critical = attacker.isThisACriticalHit();
-        if (attacker.consecutiveStuns < maxConsecutiveStuns) {
+        if (attacker.consecutiveStuns < Globals.maxConsecutiveStuns) {
             stun = attacker.stun(defender.getStat("will"));
         }
         

--- a/bin/Fight/Fight.js
+++ b/bin/Fight/Fight.js
@@ -142,7 +142,7 @@ class Fight {
         
         // Crit + stun does 25% more dmg, crit does double, else default
         if (critical && stun) {
-            damage * 1.25;
+            damage * 1.5;
         } else if (critical) {
             damage * 2;
         }

--- a/bin/Fight/Fight.js
+++ b/bin/Fight/Fight.js
@@ -133,13 +133,15 @@ class Fight {
         damage = damage * (redFlat <= 0.2 ? 0.2 : redFlat);
         damage = Math.round(damage);
 
-        // Critical hit
+        // Critical hit and stun
         critical = attacker.isThisACriticalHit();
-        damage = critical === true ? damage * 2 : damage;
-
-        // Calcul du stun si pas critique
-        if (!critical) {
-            stun = attacker.stun(defender.getStat("will"));
+        stun = attacker.stun(defender.getStat("will"));
+        
+        // Crit + stun does 25% more dmg, crit does double, else default
+        if (critical && stun) {
+            damage * 1.25;
+        } else if (critical) {
+            damage * 2;
         }
 
         defender.actualHP -= damage;

--- a/bin/Fight/Fight.js
+++ b/bin/Fight/Fight.js
@@ -136,7 +136,9 @@ class Fight {
 
         // Critical hit and stun
         critical = attacker.isThisACriticalHit();
-        stun = attacker.stun(defender.getStat("will"));
+        if (attacker.consecutiveStuns < maxConsecutiveStuns) {
+            stun = attacker.stun(defender.getStat("will"));
+        }
         
         // Crit + stun does 25% more dmg, crit does double, else default
         if (critical && stun) {
@@ -151,7 +153,7 @@ class Fight {
 
         this.log(attacker, defender, critical, stun, damage, this.initiative[0]);
 
-        if (stun && attacker.consecutiveStuns < maxConsecutiveStuns) {
+        if (stun) {
             if (this.entitiesStunned.indexOf(defender) == -1) {
                 this.entitiesStunned.push(defender);
                 attacker.consecutiveStuns += 1;

--- a/bin/Fight/Fight.js
+++ b/bin/Fight/Fight.js
@@ -122,6 +122,7 @@ class Fight {
         let done = 0;
         let critical = false;
         let stun = false;
+        const maxConsecutiveStuns = 1;
 
         let attacker = this.entities[this.initiative[0]][this.initiative[1]];
         let defender = this.getDefender(this.entities[this.initiative[0] == 0 ? 1 : 0]);
@@ -150,9 +151,12 @@ class Fight {
 
         this.log(attacker, defender, critical, stun, damage, this.initiative[0]);
 
-        if (stun) {
+        if (stun && attacker.consecutiveStuns < maxConsecutiveStuns) {
             if (this.entitiesStunned.indexOf(defender) == -1) {
                 this.entitiesStunned.push(defender);
+                attacker.consecutiveStuns += 1;
+            } else {
+                attacker.consecutiveStuns = 0;
             }
         }
 

--- a/bin/Fight/Fight.js
+++ b/bin/Fight/Fight.js
@@ -153,13 +153,11 @@ class Fight {
 
         this.log(attacker, defender, critical, stun, damage, this.initiative[0]);
 
-        if (stun) {
-            if (this.entitiesStunned.indexOf(defender) == -1) {
-                this.entitiesStunned.push(defender);
-                attacker.consecutiveStuns += 1;
-            } else {
-                attacker.consecutiveStuns = 0;
-            }
+        if (stun && this.entitiesStunned.indexOf(defender) == -1) {
+            this.entitiesStunned.push(defender);
+            attacker.consecutiveStuns += 1;
+        } else {
+            attacker.consecutiveStuns = 0;
         }
 
         if (defender.actualHP <= 0) {

--- a/bin/Fight/Fight.js
+++ b/bin/Fight/Fight.js
@@ -140,7 +140,7 @@ class Fight {
             stun = attacker.stun(defender.getStat("will"));
         }
         
-        // Crit + stun does 25% more dmg, crit does double, else default
+        // Crit + stun does 50% more dmg, crit does double, else default
         if (critical && stun) {
             damage * 1.5;
         } else if (critical) {

--- a/bin/Globals.js
+++ b/bin/Globals.js
@@ -61,6 +61,7 @@ var Globals = {
     "areasTypes": null,
     "chanceToFightTheMonsterYouWant": 0.63,
     "resetStatsPricePerLevel": 60,
+    "maxConsecutiveStuns": 1,
     "guilds": {
         "maxLevel": 10,
         "basePriceLevel": 20000,


### PR DESCRIPTION
Enables crits and stuns to trigger both at once, dealing 150% dmg instead of 200% but also stunning. Also makes it so every WorldEntity can't deal a stun twice on a row.
Overall game balance should be about the same.

I think the Area.js change should do nothing, it already looks identical to the current area.js, it was a ghost change, please check